### PR TITLE
render the initial state of checkboxes correctly even if they are radiobuttons in disguise and the first checkbox is not checked

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1580,7 +1580,7 @@ class CheckboxWidgetAnnotationElement extends WidgetAnnotationElement {
     });
 
     // #1737 modified by ngx-extended-pdf-viewer
-    window.registerAcroformField(id, element, value ? data.exportValue : false);
+    window.registerAcroformField(id, element, value ? data.exportValue : undefined, undefined, data.fieldValue);
     element.addEventListener("updateFromAngular", newvalue => storage.setValue(id, { value: newvalue.detail }));
     // #1887 end of modification by ngx-extended-pdf-viewer
     if (updateAngularValueNecessary) {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1165,6 +1165,7 @@ class TextWidgetAnnotationElement extends WidgetAnnotationElement {
       const storedData = angularData.value ? angularData : formData;
       if (angularData !== formData) {
         storage.setValue(id, { value: angularData.value });
+        storedData.formattedValue = angularData.value;
       }
       // #1737 + #1887 end of modification by ngx-extended-pdf-viewer
       let textContent = storedData.value || "";

--- a/web/ngx-extended-pdf-viewer-version.js
+++ b/web/ngx-extended-pdf-viewer-version.js
@@ -1,1 +1,1 @@
-export const ngxExtendedPdfViewerVersion = '18.1.12';
+export const ngxExtendedPdfViewerVersion = '18.1.15';


### PR DESCRIPTION
Backport of fixes for https://github.com/stephanrauh/ngx-extended-pdf-viewer/issues/2331 to v18.1.x branch