### PR TITLE
feat: add page reordering

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -528,6 +528,7 @@ class WorkerMessageHandler {
       return pdfManager.ensureDoc("calculationOrderIds");
     });
 
+    // #2943 modified by ngx-extended-pdf-viewer
     handler.on(
       "SaveDocument",
       async function ({isPureXfa, numPages, annotationStorage, filename, pageOrder = null}) {
@@ -754,6 +755,7 @@ class WorkerMessageHandler {
         });
       }
     );
+    // #2943 end of modification by ngx-extended-pdf-viewer
 
     handler.on("GetOperatorList", function (data, sink) {
       const pageIndex = data.pageIndex;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -25,19 +25,16 @@ import {
   VerbosityLevel,
   warn,
 } from "../shared/util.js";
-import {
-  arrayBuffersToBytes,
-  getNewAnnotationsMap,
-  XRefParseException,
-} from "./core_utils.js";
-import { Dict, isDict, Ref, RefSetCache } from "./primitives.js";
-import { LocalPdfManager, NetworkPdfManager } from "./pdf_manager.js";
-import { MessageHandler, wrapReason } from "../shared/message_handler.js";
-import { AnnotationFactory } from "./annotation.js";
-import { clearGlobalCaches } from "./cleanup_helper.js";
-import { incrementalUpdate } from "./writer.js";
-import { PDFWorkerStream } from "./worker_stream.js";
-import { StructTreeRoot } from "./struct_tree.js";
+import {arrayBuffersToBytes, getNewAnnotationsMap, XRefParseException,} from "./core_utils.js";
+import {Dict, isDict, Ref, RefSetCache} from "./primitives.js";
+import {LocalPdfManager, NetworkPdfManager} from "./pdf_manager.js";
+import {MessageHandler, wrapReason} from "../shared/message_handler.js";
+import {AnnotationFactory} from "./annotation.js";
+import {clearGlobalCaches} from "./cleanup_helper.js";
+import {incrementalUpdate} from "./writer.js";
+import {PDFWorkerStream} from "./worker_stream.js";
+import {StructTreeRoot} from "./struct_tree.js";
+import {Catalog} from "./catalog.js";
 
 // modified by ngx-extended-pdf-viewer #358
 // (several not-so-old browsers don't implement Promise.allSettled())
@@ -133,7 +130,7 @@ class WorkerMessageHandler {
     const WorkerTasks = new Set();
     const verbosity = getVerbosityLevel();
 
-    const { docId, apiVersion } = docParams;
+    const {docId, apiVersion} = docParams;
     const workerVersion =
       typeof PDFJSDev !== "undefined" && !PDFJSDev.test("TESTING")
         ? PDFJSDev.eval("BUNDLE_VERSION")
@@ -141,7 +138,7 @@ class WorkerMessageHandler {
     if (apiVersion !== workerVersion) {
       throw new Error(
         `The API version "${apiVersion}" does not match ` +
-          `the Worker version "${workerVersion}".`
+        `the Worker version "${workerVersion}".`
       );
     }
 
@@ -212,19 +209,19 @@ class WorkerMessageHandler {
         ? await pdfManager.ensureDoc("htmlForXfa")
         : null;
 
-      return { numPages, fingerprints, htmlForXfa };
+      return {numPages, fingerprints, htmlForXfa};
     }
 
     async function getPdfManager({
-      data,
-      password,
-      disableAutoFetch,
-      rangeChunkSize,
-      length,
-      docBaseUrl,
-      enableXfa,
-      evaluatorOptions,
-    }) {
+                                   data,
+                                   password,
+                                   disableAutoFetch,
+                                   rangeChunkSize,
+                                   length,
+                                   docBaseUrl,
+                                   enableXfa,
+                                   evaluatorOptions,
+                                 }) {
       const pdfManagerArgs = {
         source: null,
         disableAutoFetch,
@@ -279,7 +276,7 @@ class WorkerMessageHandler {
         });
 
       new Promise(function (resolve, reject) {
-        const readChunk = function ({ value, done }) {
+        const readChunk = function ({value, done}) {
           try {
             ensureNotTerminated();
             if (done) {
@@ -339,7 +336,7 @@ class WorkerMessageHandler {
     function setupDoc(data) {
       function onSuccess(doc) {
         ensureNotTerminated();
-        handler.send("GetDoc", { pdfInfo: doc });
+        handler.send("GetDoc", {pdfInfo: doc});
       }
 
       function onFailure(ex) {
@@ -351,7 +348,7 @@ class WorkerMessageHandler {
 
           handler
             .sendWithPromise("PasswordRequest", ex)
-            .then(function ({ password }) {
+            .then(function ({password}) {
               finishWorkerTask(task);
               pdfManager.updatePassword(password);
               pdfManagerReady();
@@ -400,7 +397,7 @@ class WorkerMessageHandler {
           pdfManager = newPdfManager;
 
           pdfManager.requestLoadedStream(/* noFetch = */ true).then(stream => {
-            handler.send("DataLoaded", { length: stream.bytes.byteLength });
+            handler.send("DataLoaded", {length: stream.bytes.byteLength});
           });
         })
         .then(pdfManagerReady, onFailure);
@@ -466,7 +463,7 @@ class WorkerMessageHandler {
       return pdfManager.ensureCatalog("jsActions");
     });
 
-    handler.on("GetPageJSActions", function ({ pageIndex }) {
+    handler.on("GetPageJSActions", function ({pageIndex}) {
       return pdfManager
         .getPage(pageIndex)
         .then(page => pdfManager.ensure(page, "jsActions"));
@@ -499,7 +496,7 @@ class WorkerMessageHandler {
       return pdfManager.requestLoadedStream().then(stream => stream.bytes);
     });
 
-    handler.on("GetAnnotations", function ({ pageIndex, intent }) {
+    handler.on("GetAnnotations", function ({pageIndex, intent}) {
       return pdfManager.getPage(pageIndex).then(function (page) {
         const task = new WorkerTask(`GetAnnotations: page ${pageIndex}`);
         startWorkerTask(task);
@@ -533,7 +530,7 @@ class WorkerMessageHandler {
 
     handler.on(
       "SaveDocument",
-      async function ({ isPureXfa, numPages, annotationStorage, filename }) {
+      async function ({isPureXfa, numPages, annotationStorage, filename, pageOrder = null}) {
         const globalPromises = [
           pdfManager.requestLoadedStream(),
           pdfManager.ensureCatalog("acroForm"),
@@ -545,6 +542,27 @@ class WorkerMessageHandler {
         ];
         const changes = new RefSetCache();
         const promises = [];
+
+        if (Array.isArray(pageOrder)) {
+          const xref = await pdfManager.ensureDoc("xref");
+          const catalog = new Catalog(pdfManager, xref);
+          const allPagesDicts = await catalog.getAllPageDicts();
+          const pageEntries = Array.from(allPagesDicts.entries());
+          const pagesRef = catalog.cloneDict().getRaw("Pages");
+          const pagesDict = await xref.fetchIfRefAsync(pagesRef);
+          const newPagesDict = pagesDict.clone();
+
+          // Update Kids using the Refs of the pages
+          const updatedKids = pageOrder.map(i => pageEntries[i - 1][1][1]);
+          newPagesDict._map.set("Kids", updatedKids);
+          for (const kidRef of updatedKids) {
+            const kidDict = await xref.fetchIfRefAsync(kidRef);
+            kidDict._map.set("Parent", pagesRef);
+            changes.put(kidRef, { data: kidDict });
+          }
+
+          changes.put(pagesRef, { data: newPagesDict });
+        }
 
         const newAnnotationsByPage = !isPureXfa
           ? getNewAnnotationsMap(annotationStorage)
@@ -764,7 +782,7 @@ class WorkerMessageHandler {
               if (start) {
                 info(
                   `page=${pageIndex + 1} - getOperatorList: time=` +
-                    `${Date.now() - start}ms, len=${operatorListInfo.length}`
+                  `${Date.now() - start}ms, len=${operatorListInfo.length}`
                 );
               }
               sink.close();
@@ -784,7 +802,7 @@ class WorkerMessageHandler {
     });
 
     handler.on("GetTextContent", function (data, sink) {
-      const { pageIndex, includeMarkedContent, disableNormalization } = data;
+      const {pageIndex, includeMarkedContent, disableNormalization} = data;
 
       pdfManager.getPage(pageIndex).then(function (page) {
         const task = new WorkerTask("GetTextContent: page " + pageIndex);
@@ -808,7 +826,7 @@ class WorkerMessageHandler {
               if (start) {
                 info(
                   `page=${pageIndex + 1} - getTextContent: time=` +
-                    `${Date.now() - start}ms`
+                  `${Date.now() - start}ms`
                 );
               }
               sink.close();
@@ -880,8 +898,8 @@ class WorkerMessageHandler {
       if (data) {
         info(
           "showUnverifiedSignatures=" +
-            data +
-            ". This is an incompletely implemented feature. Signatures cannot be validated, so use it at own risk."
+          data +
+          ". This is an incompletely implemented feature. Signatures cannot be validated, so use it at own risk."
         );
       }
       self.showUnverifiedSignatures = data;
@@ -917,4 +935,4 @@ class WorkerMessageHandler {
   }
 }
 
-export { WorkerMessageHandler, WorkerTask };
+export {WorkerMessageHandler, WorkerTask};

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1023,6 +1023,7 @@ class PDFDocumentProxy {
     return this._transport.getData();
   }
 
+  // #2943 modified by ngx-extended-pdf-viewer
   /**
    * @returns {Promise<Uint8Array>} A promise that is resolved with a
    *   {Uint8Array} containing the full data of the saved document.
@@ -1030,6 +1031,7 @@ class PDFDocumentProxy {
   saveDocument(pageOrder = null) {
     return this._transport.saveDocument(pageOrder);
   }
+  // #2943 end of modification by ngx-extended-pdf-viewer
 
   /**
    * @returns {Promise<{ length: number }>} A promise that is resolved when the
@@ -2815,6 +2817,7 @@ class WorkerTransport {
     return this.messageHandler.sendWithPromise("GetData", null);
   }
 
+  // #2943 modified by ngx-extended-pdf-viewer
   saveDocument(pageOrder = null) {
     if (this.annotationStorage.size <= 0) {
       warn(
@@ -2840,6 +2843,7 @@ class WorkerTransport {
         this.annotationStorage.resetModified();
       });
   }
+  // #2943 end of modification by ngx-extended-pdf-viewer
 
   getPage(pageNumber) {
     if (

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1027,8 +1027,8 @@ class PDFDocumentProxy {
    * @returns {Promise<Uint8Array>} A promise that is resolved with a
    *   {Uint8Array} containing the full data of the saved document.
    */
-  saveDocument() {
-    return this._transport.saveDocument();
+  saveDocument(pageOrder = null) {
+    return this._transport.saveDocument(pageOrder);
   }
 
   /**
@@ -2815,7 +2815,7 @@ class WorkerTransport {
     return this.messageHandler.sendWithPromise("GetData", null);
   }
 
-  saveDocument() {
+  saveDocument(pageOrder = null) {
     if (this.annotationStorage.size <= 0) {
       warn(
         "saveDocument called while `annotationStorage` is empty, " +
@@ -2832,6 +2832,7 @@ class WorkerTransport {
           numPages: this._numPages,
           annotationStorage: map,
           filename: this._fullReader?.filename ?? null,
+          pageOrder: pageOrder
         },
         transfer
       )

--- a/web/app.js
+++ b/web/app.js
@@ -195,6 +195,7 @@ appConfig: null,
   _caretBrowsing: null,
   _isScrolling: false,
   editorUndoBar: null,
+  pageOrder: null,
 
   // Called once when the document is loaded.
   async initialize(appConfig) {
@@ -206,7 +207,7 @@ appConfig: null,
     try {
       await this.preferences.initializedPromise;
     } catch (ex) {
-      NgxConsole.error("initialize:", ex);
+      console.error("initialize:", ex);
     }
     if (AppOptions.get("pdfBugEnabled")) {
       await this._parseHashParams();
@@ -320,7 +321,7 @@ appConfig: null,
         // Ensure that the "fake" worker won't be ignored.
         AppOptions.set("workerPort", null);
       } catch (ex) {
-        NgxConsole.error("_parseHashParams:", ex);
+        console.error("_parseHashParams:", ex);
       }
     }
     if (params.has("textlayer")) {
@@ -336,7 +337,7 @@ appConfig: null,
             await loadPDFBug();
             this._PDFBug.loadCSS();
           } catch (ex) {
-            NgxConsole.error("_parseHashParams:", ex);
+            console.error("_parseHashParams:", ex);
           }
           break;
       }
@@ -347,7 +348,7 @@ appConfig: null,
         await loadPDFBug();
         this._PDFBug.init(mainContainer, enabled);
       } catch (ex) {
-        NgxConsole.error("_parseHashParams:", ex);
+        console.error("_parseHashParams:", ex);
       }
 
       const debugOpts = { pdfBug: true, fontExtraProperties: true };
@@ -857,7 +858,7 @@ appConfig: null,
     if (!AppOptions.get("supportsDocumentFonts")) {
       AppOptions.set("disableFontFace", true);
       this.l10n.get("pdfjs-web-fonts-disabled").then(msg => {
-        NgxConsole.warn(msg);
+        console.warn(msg);
       });
     }
 
@@ -909,7 +910,7 @@ appConfig: null,
     } catch (ex) {
       // The viewer could be in e.g. a cross-origin <iframe> element,
       // fallback to dispatching the event at the current `document`.
-      NgxConsole.error(`webviewerinitialized: ${ex}`);
+      console.error(`webviewerinitialized: ${ex}`);
       parent.document.dispatchEvent(event);
       // #2070 end of modification
     }
@@ -1360,7 +1361,7 @@ appConfig: null,
     this.downloadManager.download(data, this._downloadUrl, this._docFilename);
   },
 
-  async save() {
+  async save(pageOrder = null) {
     if (this._saveInProgress) {
       return;
     }
@@ -1368,7 +1369,7 @@ appConfig: null,
     await this.pdfScriptingManager.dispatchWillSave();
 
     try {
-      const data = await this.pdfDocument.saveDocument();
+      const data = await this.pdfDocument.saveDocument(pageOrder);
       this.downloadManager.download(data, this._downloadUrl, this._docFilename);
     } catch (reason) {
       // When the PDF document isn't ready, fallback to a "regular" download.
@@ -1399,10 +1400,51 @@ appConfig: null,
     // a message and change PdfjsChild.sys.mjs to take it into account.
     const { classList } = this.appConfig.appContainer;
     classList.add("wait");
-    await (this.pdfDocument?.annotationStorage.size > 0
-      ? this.save()
-      : this.download());
+    const hasChanges = this.pdfDocument?.annotationStorage.size > 0 || !this.pageOrder.every((value, index, array) =>
+      index === 0 || value >= array[index - 1]);
+    await (hasChanges ? this.save(this.pageOrder) : this.download());
     classList.remove("wait");
+  },
+
+  movePageUp(event) {
+    if(event.source.pageNumber <= 1) return
+    this.pdfViewer.swapPages(event.source.pageNumber - 1, event.source.pageNumber - 2);
+    this.pdfThumbnailViewer.swapThumbnails(event.source.pageNumber - 1, event.source.pageNumber - 2);
+    this.page = event.source.pageNumber - 1;
+    [this.pageOrder[event.source.pageNumber - 1], this.pageOrder[event.source.pageNumber]] = [this.pageOrder[event.source.pageNumber], this.pageOrder[event.source.pageNumber - 1]];
+  },
+
+  movePageDown(event) {
+    if(event.source.pageNumber === this.pdfDocument.numPages) return
+    this.pdfViewer.swapPages(event.source.pageNumber - 1, event.source.pageNumber);
+    this.pdfThumbnailViewer.swapThumbnails(event.source.pageNumber - 1, event.source.pageNumber);
+    this.page = event.source.pageNumber + 1;
+    [this.pageOrder[event.source.pageNumber - 2], this.pageOrder[event.source.pageNumber - 1]] = [this.pageOrder[event.source.pageNumber - 1], this.pageOrder[event.source.pageNumber - 2]];
+  },
+
+  movePage(prevPageIndex, newPageIndex) {
+    if (prevPageIndex < 1 || prevPageIndex > this.pdfDocument.numPages || newPageIndex < 1 || newPageIndex > this.pdfDocument.numPages) return;
+
+    const prevPageNumber = prevPageIndex - 1;
+    const newPageNumber = newPageIndex - 1;
+
+    if (prevPageNumber < newPageNumber) {
+      // Move page down
+      for (let i = prevPageNumber; i < newPageNumber; i++) {
+        this.pdfViewer.swapPages(i, i + 1);
+        this.pdfThumbnailViewer.swapThumbnails(i, i + 1);
+        [this.pageOrder[i], this.pageOrder[i + 1]] = [this.pageOrder[i + 1], this.pageOrder[i]];
+      }
+    } else if (prevPageNumber > newPageNumber) {
+      // Move page up
+      for (let i = prevPageNumber; i > newPageNumber; i--) {
+        this.pdfViewer.swapPages(i, i - 1);
+        this.pdfThumbnailViewer.swapThumbnails(i, i - 1);
+        [this.pageOrder[i], this.pageOrder[i - 1]] = [this.pageOrder[i - 1], this.pageOrder[i]];
+      }
+    }
+
+    this.page = newPageIndex;
   },
 
   // #1685 modified by ngx-extended-pdf-viewer
@@ -1507,7 +1549,7 @@ appConfig: null,
       }
     }
 
-    NgxConsole.error(`${message}\n\n${moreInfoText.join("\n")}`);
+    console.error(`${message}\n\n${moreInfoText.join("\n")}`);
     return message;
   },
 
@@ -1786,6 +1828,7 @@ appConfig: null,
 
     this._initializePageLabels(pdfDocument);
     this._initializeMetadata(pdfDocument);
+    this._initializePageOrder(pdfDocument);
   },
 
   /**
@@ -1883,16 +1926,12 @@ appConfig: null,
     this._contentLength ??= contentLength; // See `getDownloadInfo`-call above.
 
     // Provides some basic debug information
-    // #1793 modified by ngx-extended-pdf-vieweer
-    if (AppOptions?.get("verbosity") > 0) {
-      NgxConsole.log(
-        `PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` +
-          `${(metadata?.get("pdf:producer") || info.Producer || "-").trim()} / ` +
-          `${(metadata?.get("xmp:creatortool") || info.Creator || "-").trim()}` +
-          `] (PDF.js: ${version || "?"} [${build || "?"}])  modified by ngx-extended-pdf-viewer ${ngxExtendedPdfViewerVersion}`
-      );
-    }
-    // #1793 end of modification by ngx-extended-pdf-viewer
+    console.log(
+      `PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` +
+        `${(metadata?.get("pdf:producer") || info.Producer || "-").trim()} / ` +
+        `${(metadata?.get("xmp:creatortool") || info.Creator || "-").trim()}` +
+        `] (PDF.js: ${version || "?"} [${build || "?"}])`
+    );
     const pdfTitle = this._docTitle;
 
     if (pdfTitle) {
@@ -1917,14 +1956,24 @@ appConfig: null,
       (info.IsAcroFormPresent || info.IsXFAPresent) &&
       !this.pdfViewer.renderForms
     ) {
-      NgxConsole.warn("Warning: Interactive form support is not enabled");
+      console.warn("Warning: Interactive form support is not enabled");
     }
 
     if (info.IsSignaturesPresent) {
-      NgxConsole.warn("Warning: Digital signatures validation is not supported");
+      console.warn("Warning: Digital signatures validation is not supported");
     }
 
     this.eventBus.dispatch("metadataloaded", { source: this });
+  },
+
+  /**
+   * @private
+   */
+  async _initializePageOrder(pdfDocument) {
+    if (pdfDocument !== this.pdfDocument) {
+      return; // The document was closed while the page order resolved.
+    }
+    this.pageOrder = Array.from({length: this.pdfDocument.numPages}, (_, i) => i + 1);
   },
 
   /**
@@ -2262,6 +2311,8 @@ appConfig: null,
     );
     eventBus._on("print", this.triggerPrinting.bind(this), opts);
     eventBus._on("download", this.downloadOrSave.bind(this), opts);
+    eventBus._on("movePageUp", this.movePageUp.bind(this), opts);
+    eventBus._on("movePageDown", this.movePageDown.bind(this), opts);
     eventBus._on("firstpage", () => (this.page = 1), opts);
     eventBus._on("lastpage", () => (this.page = this.pagesCount), opts);
     eventBus._on("nextpage", () => pdfViewer.nextPage(), opts);

--- a/web/app.js
+++ b/web/app.js
@@ -207,7 +207,7 @@ appConfig: null,
     try {
       await this.preferences.initializedPromise;
     } catch (ex) {
-      console.error("initialize:", ex);
+      NgxConsole.error("initialize:", ex);
     }
     if (AppOptions.get("pdfBugEnabled")) {
       await this._parseHashParams();
@@ -321,7 +321,7 @@ appConfig: null,
         // Ensure that the "fake" worker won't be ignored.
         AppOptions.set("workerPort", null);
       } catch (ex) {
-        console.error("_parseHashParams:", ex);
+        NgxConsole.error("_parseHashParams:", ex);
       }
     }
     if (params.has("textlayer")) {
@@ -337,7 +337,7 @@ appConfig: null,
             await loadPDFBug();
             this._PDFBug.loadCSS();
           } catch (ex) {
-            console.error("_parseHashParams:", ex);
+            NgxConsole.error("_parseHashParams:", ex);
           }
           break;
       }
@@ -348,7 +348,7 @@ appConfig: null,
         await loadPDFBug();
         this._PDFBug.init(mainContainer, enabled);
       } catch (ex) {
-        console.error("_parseHashParams:", ex);
+        NgxConsole.error("_parseHashParams:", ex);
       }
 
       const debugOpts = { pdfBug: true, fontExtraProperties: true };
@@ -858,7 +858,7 @@ appConfig: null,
     if (!AppOptions.get("supportsDocumentFonts")) {
       AppOptions.set("disableFontFace", true);
       this.l10n.get("pdfjs-web-fonts-disabled").then(msg => {
-        console.warn(msg);
+        NgxConsole.warn(msg);
       });
     }
 
@@ -910,7 +910,7 @@ appConfig: null,
     } catch (ex) {
       // The viewer could be in e.g. a cross-origin <iframe> element,
       // fallback to dispatching the event at the current `document`.
-      console.error(`webviewerinitialized: ${ex}`);
+      NgxConsole.error(`webviewerinitialized: ${ex}`);
       parent.document.dispatchEvent(event);
       // #2070 end of modification
     }
@@ -1549,7 +1549,7 @@ appConfig: null,
       }
     }
 
-    console.error(`${message}\n\n${moreInfoText.join("\n")}`);
+    NgxConsole.error(`${message}\n\n${moreInfoText.join("\n")}`);
     return message;
   },
 
@@ -1678,7 +1678,7 @@ appConfig: null,
                 zoom = Number(zoom) / 100;
               }
             } catch (error) {
-              // console.log("Couldn't get the zoom setting", error);
+              // NgxConsole.log("Couldn't get the zoom setting", error);
             }
           }
           if (!pdfViewer.currentScaleValue && zoom && zoom !== '') {
@@ -1926,7 +1926,7 @@ appConfig: null,
     this._contentLength ??= contentLength; // See `getDownloadInfo`-call above.
 
     // Provides some basic debug information
-    console.log(
+    NgxConsole.log(
       `PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` +
         `${(metadata?.get("pdf:producer") || info.Producer || "-").trim()} / ` +
         `${(metadata?.get("xmp:creatortool") || info.Creator || "-").trim()}` +
@@ -1956,11 +1956,11 @@ appConfig: null,
       (info.IsAcroFormPresent || info.IsXFAPresent) &&
       !this.pdfViewer.renderForms
     ) {
-      console.warn("Warning: Interactive form support is not enabled");
+      NgxConsole.warn("Warning: Interactive form support is not enabled");
     }
 
     if (info.IsSignaturesPresent) {
-      console.warn("Warning: Digital signatures validation is not supported");
+      NgxConsole.warn("Warning: Digital signatures validation is not supported");
     }
 
     this.eventBus.dispatch("metadataloaded", { source: this });

--- a/web/app.js
+++ b/web/app.js
@@ -1926,12 +1926,16 @@ appConfig: null,
     this._contentLength ??= contentLength; // See `getDownloadInfo`-call above.
 
     // Provides some basic debug information
-    NgxConsole.log(
-      `PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` +
-        `${(metadata?.get("pdf:producer") || info.Producer || "-").trim()} / ` +
-        `${(metadata?.get("xmp:creatortool") || info.Creator || "-").trim()}` +
-        `] (PDF.js: ${version || "?"} [${build || "?"}])`
-    );
+    // #1793 modified by ngx-extended-pdf-vieweer
+    if (AppOptions?.get("verbosity") > 0) {
+      NgxConsole.log(
+        `PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` +
+          `${(metadata?.get("pdf:producer") || info.Producer || "-").trim()} / ` +
+          `${(metadata?.get("xmp:creatortool") || info.Creator || "-").trim()}` +
+          `] (PDF.js: ${version || "?"} [${build || "?"}])  modified by ngx-extended-pdf-viewer ${ngxExtendedPdfViewerVersion}`
+      );
+    }
+    // #1793 end of modification by ngx-extended-pdf-viewer
     const pdfTitle = this._docTitle;
 
     if (pdfTitle) {

--- a/web/app.js
+++ b/web/app.js
@@ -195,7 +195,9 @@ appConfig: null,
   _caretBrowsing: null,
   _isScrolling: false,
   editorUndoBar: null,
+  // #2943 modified by ngx-extended-pdf-viewer
   pageOrder: null,
+  // #2943 end of modification by ngx-extended-pdf-viewer
 
   // Called once when the document is loaded.
   async initialize(appConfig) {
@@ -1361,6 +1363,7 @@ appConfig: null,
     this.downloadManager.download(data, this._downloadUrl, this._docFilename);
   },
 
+  // #2943 modified by ngx-extended-pdf-viewer
   async save(pageOrder = null) {
     if (this._saveInProgress) {
       return;
@@ -1446,6 +1449,7 @@ appConfig: null,
 
     this.page = newPageIndex;
   },
+  // #2943 end of modification by ngx-extended-pdf-viewer
 
   // #1685 modified by ngx-extended-pdf-viewer
   async _exportWithAnnotations() {
@@ -1828,7 +1832,9 @@ appConfig: null,
 
     this._initializePageLabels(pdfDocument);
     this._initializeMetadata(pdfDocument);
+    // #2943 modified by ngx-extended-pdf-viewer
     this._initializePageOrder(pdfDocument);
+    // #2943 end of modification by ngx-extended-pdf-viewer
   },
 
   /**
@@ -1970,6 +1976,7 @@ appConfig: null,
     this.eventBus.dispatch("metadataloaded", { source: this });
   },
 
+  // #2943 modified by ngx-extended-pdf-viewer
   /**
    * @private
    */
@@ -1979,6 +1986,7 @@ appConfig: null,
     }
     this.pageOrder = Array.from({length: this.pdfDocument.numPages}, (_, i) => i + 1);
   },
+  // #2943 end of modification by ngx-extended-pdf-viewer
 
   /**
    * @private
@@ -2315,8 +2323,10 @@ appConfig: null,
     );
     eventBus._on("print", this.triggerPrinting.bind(this), opts);
     eventBus._on("download", this.downloadOrSave.bind(this), opts);
+    // #2943 modified by ngx-extended-pdf-viewer
     eventBus._on("movePageUp", this.movePageUp.bind(this), opts);
     eventBus._on("movePageDown", this.movePageDown.bind(this), opts);
+    // #2943 end of modification by ngx-extended-pdf-viewer
     eventBus._on("firstpage", () => (this.page = 1), opts);
     eventBus._on("lastpage", () => (this.page = this.pagesCount), opts);
     eventBus._on("nextpage", () => pdfViewer.nextPage(), opts);

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -27,10 +27,12 @@ import { OutputScale, RenderingCancelledException } from "pdfjs-lib";
 import { AppOptions } from "./app_options.js";
 import { NgxConsole } from "../external/ngx-logger/ngx-console.js";
 import { RenderingStates } from "./ui_utils.js";
+import {PDFViewerApplication} from "./app.js";
 
 const DRAW_UPSCALE_FACTOR = 2; // See comment in `PDFThumbnailView.draw` below.
 const MAX_NUM_SCALING_STEPS = 3;
 const THUMBNAIL_WIDTH = 98; // px
+let initialDragY = 0;
 
 function zeroCanvas(c) {
   // Zeroing the width and height causes Firefox to release graphics
@@ -147,6 +149,70 @@ class PDFThumbnailView {
       this.createThumbnail(this, linkService, id, container, this.#pageL10nArgs);
     }
     // end of modification
+
+    this.div.addEventListener('dragstart', this._dragStartHandler.bind(this));
+    this.div.addEventListener('dragover', this._dragOverHandler.bind(this));
+    this.div.addEventListener('drop', this._dropHandler.bind(this));
+    this.div.addEventListener('mousedown', this._mouseDownHandler.bind(this));
+  }
+
+  _dragStartHandler(event) {
+    event.dataTransfer.setData('text/plain', this.id.toString());
+  }
+
+  _dragOverHandler(event) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const target = event.currentTarget;
+    const bounding = target.getBoundingClientRect();
+    this._removeDottedLine();
+    // Don't show line for initial dragged item
+    if(bounding.top < initialDragY && bounding.bottom > initialDragY) {
+      return;
+    }
+    this._showDottedLine(target, bounding.height, initialDragY > event.clientY);
+  }
+
+  _dropHandler(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const draggedId = parseInt(event.dataTransfer.getData('text/plain'), 10);
+    const targetId = this.id;
+    this._removeDottedLine();
+    if (draggedId !== targetId) {
+      this._movePage(draggedId, targetId);
+    }
+  }
+
+  _mouseDownHandler(event) {
+    initialDragY = event.clientY;
+  }
+
+  _showDottedLine(target, height, insertAbove) {
+    const dottedLine = document.createElement('div');
+    dottedLine.className = 'dotted-line';
+    if (insertAbove) {
+      dottedLine.style.setProperty("--dotted-line-margin-x", `${-(height)}px`);
+    } else {
+      dottedLine.style.setProperty("--dotted-line-margin-x", "6px");
+    }
+    target.appendChild(dottedLine);
+  }
+
+  _removeDottedLine() {
+    const existingLine = document.querySelector('.dotted-line');
+    if (existingLine) {
+      existingLine.parentNode.removeChild(existingLine);
+    }
+  }
+
+  _movePage(draggedId, targetId) {
+    const thumbnailsContainer = this.div.parentNode.parentNode;
+    const draggedThumbnail = thumbnailsContainer.children[draggedId - 1];
+    const targetThumbnail = thumbnailsContainer.children[targetId - 1];
+    if (draggedThumbnail && targetThumbnail) {
+      PDFViewerApplication.movePage(draggedId, targetId);
+    }
   }
 
   // modified by ngx-extended-pdf-viewer

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -32,7 +32,9 @@ import {PDFViewerApplication} from "./app.js";
 const DRAW_UPSCALE_FACTOR = 2; // See comment in `PDFThumbnailView.draw` below.
 const MAX_NUM_SCALING_STEPS = 3;
 const THUMBNAIL_WIDTH = 98; // px
+// #2943 modified by ngx-extended-pdf-viewer
 let initialDragY = 0;
+// #2943 end of modification by ngx-extended-pdf-viewer
 
 function zeroCanvas(c) {
   // Zeroing the width and height causes Firefox to release graphics
@@ -150,6 +152,7 @@ class PDFThumbnailView {
     }
     // end of modification
 
+    // #2943 modified by ngx-extended-pdf-viewer
     this.div.addEventListener('dragstart', this._dragStartHandler.bind(this));
     this.div.addEventListener('dragover', this._dragOverHandler.bind(this));
     this.div.addEventListener('drop', this._dropHandler.bind(this));
@@ -214,6 +217,7 @@ class PDFThumbnailView {
       PDFViewerApplication.movePage(draggedId, targetId);
     }
   }
+  // #2943 end of modification by ngx-extended-pdf-viewer
 
   // modified by ngx-extended-pdf-viewer
   createThumbnail(pdfThumbnailView, linkService, id, container, pageL10nArgs) {

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -169,6 +169,12 @@ class PDFThumbnailViewer {
     }
   }
 
+  swapThumbnails(prevIndex, newIndex) {
+    let prevIndexPage = this._thumbnails[prevIndex].pdfPage
+    this._thumbnails[prevIndex].setPdfPage(this._thumbnails[newIndex].pdfPage);
+    this._thumbnails[newIndex].setPdfPage(prevIndexPage);
+  }
+
   cleanup() {
     for (const thumbnail of this._thumbnails) {
       if (thumbnail.renderingState !== RenderingStates.FINISHED) {
@@ -219,7 +225,6 @@ class PDFThumbnailViewer {
         for (let pageNum = 1; pageNum <= pagesCount; ++pageNum) {
           const thumbnail = new PDFThumbnailView({
             container: this.container,
-            eventBus: this.eventBus,
             id: pageNum,
             defaultViewport: viewport.clone(),
             optionalContentConfigPromise,

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -169,11 +169,13 @@ class PDFThumbnailViewer {
     }
   }
 
+  // #2943 modified by ngx-extended-pdf-viewer
   swapThumbnails(prevIndex, newIndex) {
     let prevIndexPage = this._thumbnails[prevIndex].pdfPage
     this._thumbnails[prevIndex].setPdfPage(this._thumbnails[newIndex].pdfPage);
     this._thumbnails[newIndex].setPdfPage(prevIndexPage);
   }
+  // #2943 end of modification by ngx-extended-pdf-viewer
 
   cleanup() {
     for (const thumbnail of this._thumbnails) {

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -31,7 +31,9 @@
   --loading-icon-delay: 400ms;
   --focus-ring-color: light-dark(#0060df, #0df);
   --focus-ring-outline: 2px solid var(--focus-ring-color);
+  /* #2943 modified by ngx-extended-pdf-viewer */
   --dotted-line-margin-x: 6px;
+  /* #2943 end of modification by ngx-extended-pdf-viewer */
 
   @media screen and (forced-colors: active) {
     --pdfViewer-padding-bottom: 9px;
@@ -223,7 +225,9 @@
   border: 2px solid transparent;
 }
 
+/* #2943 modified by ngx-extended-pdf-viewer */
 .dotted-line {
   border-top: 2px dotted lightslategrey;
   margin: var(--dotted-line-margin-x) 0;
 }
+/* #2943 end of modification by ngx-extended-pdf-viewer */

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -31,6 +31,7 @@
   --loading-icon-delay: 400ms;
   --focus-ring-color: light-dark(#0060df, #0df);
   --focus-ring-outline: 2px solid var(--focus-ring-color);
+  --dotted-line-margin-x: 6px;
 
   @media screen and (forced-colors: active) {
     --pdfViewer-padding-bottom: 9px;
@@ -220,4 +221,9 @@
 .pdfPresentationMode .pdfViewer .page {
   margin: 0 auto;
   border: 2px solid transparent;
+}
+
+.dotted-line {
+  border-top: 2px dotted lightslategrey;
+  margin: var(--dotted-line-margin-x) 0;
 }

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -505,6 +505,7 @@ class PDFViewer {
     return this._pages[index];
   }
 
+  // #2943 modified by ngx-extended-pdf-viewer
   swapPages(oldIndex, newIndex) {
     const oldIndexPage = this._pages[oldIndex].pdfPage;
     const newIndexPage = this._pages[newIndex].pdfPage;
@@ -512,6 +513,7 @@ class PDFViewer {
     this._pages[newIndex].setPdfPage(oldIndexPage);
     this.refresh();
   }
+  // #2943 end of modification by ngx-extended-pdf-viewer
 
   getCachedPageViews() {
     return new Set(this.#buffer);

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -497,13 +497,20 @@ class PDFViewer {
   }
   // #1989 end of modification by ngx-extended-pdf-viewer
 
-
   get pagesCount() {
     return this._pages.length;
   }
 
   getPageView(index) {
     return this._pages[index];
+  }
+
+  swapPages(oldIndex, newIndex) {
+    const oldIndexPage = this._pages[oldIndex].pdfPage;
+    const newIndexPage = this._pages[newIndex].pdfPage;
+    this._pages[oldIndex].setPdfPage(newIndexPage);
+    this._pages[newIndex].setPdfPage(oldIndexPage);
+    this.refresh();
   }
 
   getCachedPageViews() {

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -45,8 +45,10 @@ import {
  * @property {HTMLButtonElement} editorFreeTextButton - Button to switch to
  *   FreeText editing.
  * @property {HTMLButtonElement} download - Button to download the document.
+ * #2943 modified by ngx-extended-pdf-viewer
  * @property {HTMLButtonElement} movePageUp - Button to move a page up inside the document.
  * @property {HTMLButtonElement} movePageDown - Button to move a page down inside the document.
+ * #2943 end of modification by ngx-extended-pdf-viewer
  */
 
 class Toolbar {
@@ -93,8 +95,10 @@ class Toolbar {
       },
       // #1807 end of modication by ngx-extended-pdf-viewer
       { element: options.download, eventName: "download" },
+      // #2943 modified by ngx-extended-pdf-viewer
       { element: options.movePageUp, eventName: "movePageUp" },
       { element: options.movePageDown, eventName: "movePageDown" },
+      // #2943 end of modification by ngx-extended-pdf-viewer
       // #2900 modified by ngx-extended-pdf-viewer - deactivate the buttons
       // because they're handled by TypeScript
       /*

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -45,6 +45,8 @@ import {
  * @property {HTMLButtonElement} editorFreeTextButton - Button to switch to
  *   FreeText editing.
  * @property {HTMLButtonElement} download - Button to download the document.
+ * @property {HTMLButtonElement} movePageUp - Button to move a page up inside the document.
+ * @property {HTMLButtonElement} movePageDown - Button to move a page down inside the document.
  */
 
 class Toolbar {
@@ -91,6 +93,8 @@ class Toolbar {
       },
       // #1807 end of modication by ngx-extended-pdf-viewer
       { element: options.download, eventName: "download" },
+      { element: options.movePageUp, eventName: "movePageUp" },
+      { element: options.movePageDown, eventName: "movePageDown" },
       // #2900 modified by ngx-extended-pdf-viewer - deactivate the buttons
       // because they're handled by TypeScript
       /*
@@ -319,6 +323,7 @@ class Toolbar {
           break;
       }
     });
+
     eventBus._on("toolbardensity", this.#updateToolbarDensity.bind(this));
 
     if (editorHighlightColorPicker) {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -528,6 +528,14 @@ body {
   mask-image: var(--toolbarButton-editorFreeText-icon);
 }
 
+#movePageUpButton::before {
+  mask-image: var(--toolbarButton-pageUp-icon);
+}
+
+#movePageDownButton::before {
+  mask-image: var(--toolbarButton-pageDown-icon);
+}
+
 #editorHighlightButton::before {
   mask-image: var(--toolbarButton-editorHighlight-icon);
 }

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -528,6 +528,7 @@ body {
   mask-image: var(--toolbarButton-editorFreeText-icon);
 }
 
+/* #2943 modified by ngx-extended-pdf-viewer */
 #movePageUpButton::before {
   mask-image: var(--toolbarButton-pageUp-icon);
 }
@@ -535,6 +536,7 @@ body {
 #movePageDownButton::before {
   mask-image: var(--toolbarButton-pageDown-icon);
 }
+/* #2943 end of modification by ngx-extended-pdf-viewer */
 
 #editorHighlightButton::before {
   mask-image: var(--toolbarButton-editorHighlight-icon);

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -262,6 +262,16 @@ See https://github.com/adobe-type-tools/cmap-resources
                       </div>
                     </div>
                   </div>
+                  <div id="movePageUp" class="toolbarButtonWithContainer">
+                    <button id="movePageUpButton" class="toolbarButton" type="button" role="radio" aria-expanded="false" aria-haspopup="false" aria-controls="movePageUpParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-movePageUp-button">
+                      <span data-l10n-id="pdfjs-editor-movePageUp-button-label"></span>
+                    </button>
+                  </div>
+                  <div id="movePageDown" class="toolbarButtonWithContainer">
+                    <button id="movePageDownButton" class="toolbarButton" type="button" role="radio" aria-expanded="false" aria-haspopup="false" aria-controls="movePageDownParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-movePageDown-button">
+                      <span data-l10n-id="pdfjs-editor-movePageDown-button-label"></span>
+                    </button>
+                  </div>
                   <div id="editorHighlight" class="toolbarButtonWithContainer">
                     <button id="editorHighlightButton" class="toolbarButton" type="button" disabled="disabled" role="radio" aria-expanded="false" aria-haspopup="true" aria-controls="editorHighlightParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-highlight-button">
                       <span data-l10n-id="pdfjs-editor-highlight-button-label"></span>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -262,6 +262,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                       </div>
                     </div>
                   </div>
+                  <!-- #2943 modified by ngx-extended-pdf-viewer -->
                   <div id="movePageUp" class="toolbarButtonWithContainer">
                     <button id="movePageUpButton" class="toolbarButton" type="button" role="radio" aria-expanded="false" aria-haspopup="false" aria-controls="movePageUpParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-movePageUp-button">
                       <span data-l10n-id="pdfjs-editor-movePageUp-button-label"></span>
@@ -272,6 +273,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <span data-l10n-id="pdfjs-editor-movePageDown-button-label"></span>
                     </button>
                   </div>
+                  <!-- #2943 end of modification by ngx-extended-pdf-viewer -->
                   <div id="editorHighlight" class="toolbarButtonWithContainer">
                     <button id="editorHighlightButton" class="toolbarButton" type="button" disabled="disabled" role="radio" aria-expanded="false" aria-haspopup="true" aria-controls="editorHighlightParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-highlight-button">
                       <span data-l10n-id="pdfjs-editor-highlight-button-label"></span>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -101,6 +101,8 @@ function getViewerConfiguration() {
         "editorSignatureParamsToolbar"
       ),
       download: document.getElementById("downloadButton"),
+      movePageUp: document.getElementById("movePageUpButton"),
+      movePageDown: document.getElementById("movePageDownButton"),
     },
     secondaryToolbar: {
       toolbar: document.getElementById("secondaryToolbar"),

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -101,8 +101,10 @@ function getViewerConfiguration() {
         "editorSignatureParamsToolbar"
       ),
       download: document.getElementById("downloadButton"),
+      // #2943 modified by ngx-extended-pdf-viewer
       movePageUp: document.getElementById("movePageUpButton"),
       movePageDown: document.getElementById("movePageDownButton"),
+      // #2943 end of modification by ngx-extended-pdf-viewer
     },
     secondaryToolbar: {
       toolbar: document.getElementById("secondaryToolbar"),


### PR DESCRIPTION
Adds basic page reordering functionality as discussed in the [ngx-extended-pdf-viewer](https://github.com/stephanrauh/ngx-extended-pdf-viewer) repo, issue [#2943](https://github.com/stephanrauh/ngx-extended-pdf-viewer/issues/2943).

I am piggybacking on the existing save functionality to ensure the updated order is enforced inside downloaded documents, it might make sense to separate this out completely for a cleaner implementation.

Please note that there is currently no tooltip on hover to tell the user what the two new buttons do.