### PR TITLE
minor comment editing fixes (for stephanrauh/ngx-extended-pdf-viewer#3113)

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -794,15 +794,19 @@ class ColorScheme {
 
 class CSSConstants {
   static get commentForegroundColor() {
+    // modified by ngx-extended-pdf-viewer
+    const dummyComponent = document.createElement("ngx-extended-pdf-viewer");
+    dummyComponent.style.display = "block";
     const element = document.createElement("span");
-    element.classList.add("comment", "sidebar");
+    element.classList.add("commentPopup", "comment", "sidebar");
     const { style } = element;
     style.width = style.height = "0";
     style.display = "none";
     style.color = "var(--comment-fg-color)";
-    document.body.append(element);
+    dummyComponent.append(element);
+    document.body.append(dummyComponent);
     const { color } = window.getComputedStyle(element);
-    element.remove();
+    dummyComponent.remove();
     return shadow(this, "commentForegroundColor", getRGB(color));
   }
 }

--- a/src/display/editor/comment.js
+++ b/src/display/editor/comment.js
@@ -321,6 +321,16 @@ class Comment {
     this.#richText = richText;
   }
 
+  // modified by ngx-extended-pdf-viewer
+  setDate(date) {
+    const dateObj = date && new Date(date);
+    if (!dateObj || isNaN(dateObj)) {
+      this.#date = new Date();
+    } else {
+      this.#date = dateObj;
+    }
+  }
+
   shown() {}
 
   destroy() {

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -1292,12 +1292,17 @@ class AnnotationEditor {
     }
   }
 
-  setCommentData({ comment, popupRef, richText }) {
+  // modified by ngx-extended-pdf-viewer
+  setCommentData({ comment, popupRef, richText, commentDate }) {
     if (!popupRef) {
       return;
     }
     this.#comment ||= new Comment(this);
     this.#comment.setInitialText(comment, richText);
+    // modified by ngx-extended-pdf-viewer
+    if (commentDate) {
+      this.#comment.setDate(commentDate);
+    }
 
     if (!this.annotationElementId) {
       return;
@@ -1353,6 +1358,8 @@ class AnnotationEditor {
         contents: this.comment.text,
         deleted: this.comment.deleted,
         rect: [blX, blY, trX, trY],
+        // modified by ngx-extended-pdf-viewer
+        date: this.comment.date?.toISOString()
       };
     }
   }

--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -962,7 +962,8 @@ class HighlightEditor extends AnnotationEditor {
       };
     } else if (data.annotationType && data.annotationType === AnnotationEditorType.HIGHLIGHT) {
       // eslint-disable-next-line prefer-const
-      let { quadPoints, outlines, rect, rotation, id, color, opacity, popupRef, pageIndex, thickness } = data;
+      // modified by ngx-extended-pdf-viewer
+      let { quadPoints, outlines, rect, rotation, id, color, opacity, popup, popupRef, pageIndex, thickness } = data;
 
       // Ensure quadPoints is an array
       if (quadPoints) {
@@ -1000,7 +1001,10 @@ class HighlightEditor extends AnnotationEditor {
         rotation,
         id,
         deleted: false,
-        popupRef: popupRef || null,
+        // modified by ngx-extended-pdf-viewer
+        popupRef: popupRef || !!(popup && popup.contents && !popup.deleted) || null,
+        comment: (!popup?.deleted && popup?.contents) || null,
+        commentDate: (!popup?.deleted && popup?.date) || null,
       };
     } else if (data instanceof InkAnnotationElement) {
       const {

--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -178,6 +178,16 @@ class InkEditor extends DrawingEditor {
         creationDate,
         modificationDate,
       };
+    } else {
+      // modified by ngx-extended-pdf-viewer
+      const { popup, popupRef } = data;
+
+      initialData = data = {
+        ...data,
+        popupRef: popupRef || !!(popup && popup.contents && !popup.deleted) || null,
+        comment: (!popup?.deleted && popup?.contents) || null,
+        commentDate: (!popup?.deleted && popup?.date) || null,
+      }
     }
 
     const editor = await super.deserialize(data, parent, uiManager);

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -821,6 +821,16 @@ class StampEditor extends AnnotationEditor {
         creationDate,
         modificationDate,
       };
+    } else {
+      // modified by ngx-extended-pdf-viewer
+      const { popup, popupRef } = data;
+
+      initialData = data = {
+        ...data,
+        popupRef: popupRef || !!(popup && popup.contents && !popup.deleted) || null,
+        comment: (!popup?.deleted && popup?.contents) || null,
+        commentDate: (!popup?.deleted && popup?.date) || null,
+      }
     }
     const editor = await super.deserialize(data, parent, uiManager);
     const { rect, bitmap, bitmapUrl, bitmapId, isSvg, accessibilityData } =

--- a/web/comment_manager.js
+++ b/web/comment_manager.js
@@ -908,14 +908,25 @@ class CommentPopup {
   }
 
   get _popupWidth() {
-    const container = this.#createPopup();
-    const { style } = container;
-    style.opacity = "0";
-    style.display = "block";
-    document.body.append(container);
-    const width = container.getBoundingClientRect().width;
-    container.remove();
-    style.opacity = style.display = "";
+    // modified by ngx-extended-pdf-viewer
+    const dummyComponent = document.createElement("ngx-extended-pdf-viewer");
+    dummyComponent.style.opacity = "0";
+    dummyComponent.style.display = "block";
+
+    const zoomContainer = document.createElement("div");
+    zoomContainer.classList.add("zoom");
+    dummyComponent.append(zoomContainer);
+
+    const popupContainer = this.#createPopup();
+    popupContainer.style.display = "block";
+    zoomContainer.append(popupContainer);
+
+    document.body.append(dummyComponent);
+
+    const width = popupContainer.getBoundingClientRect().width;
+    popupContainer.remove();
+    dummyComponent.remove();
+    popupContainer.style.display = "";
     return shadow(this, "_popupWidth", width);
   }
 
@@ -1198,7 +1209,8 @@ class CommentPopup {
         const buttonWidth = this.#editor.commentButtonWidth;
         x -= widthRatio - buttonWidth;
       }
-      const margin = 0.01;
+      // modified by ngx-extended-pdf-viewer
+      const margin = 0.02;
       if (this.#isLTR) {
         x = Math.max(x, -parentRect.x / parentRect.width + margin);
       } else {

--- a/web/comment_manager.js
+++ b/web/comment_manager.js
@@ -838,6 +838,17 @@ class CommentDialog {
         },
       },
     });
+    // modified by ngx-extended-pdf-viewer
+    if (edited) {
+      this.#eventBus?.dispatch("annotation-editor-event", {
+        source: this,
+        type: this.#textInput.value ? 'commented' : 'commentRemoved',
+        page: this.#editor.pageIndex + 1,
+        id: this.#editor.uid,
+        editorType: this.#editor.constructor.name,
+        value: this.#editor,
+      });
+    }
 
     this.#editor?.focusCommentButton();
     this.#editor = null;
@@ -983,6 +994,15 @@ class CommentPopup {
         },
       });
       this.#editor.comment = null;
+      // modified by ngx-extended-pdf-viewer
+      this.#eventBus?.dispatch("annotation-editor-event", {
+        source: this,
+        type: 'commentRemoved',
+        page: this.#editor.pageIndex + 1,
+        id: this.#editor.uid,
+        editorType: this.#editor.constructor.name,
+        value: this.#editor,
+      });
       this.#editor.focus();
       this.destroy();
     });


### PR DESCRIPTION
Related to https://github.com/stephanrauh/ngx-extended-pdf-viewer/pull/3113

- Update to 5.4.394 (no real merge conflicts)
- Actually add comments stored in the `popup` field of the serialized annotation when loading from JSON representation
- Emit events on comment creation/modification and comment removal
- Adapt two functions that relied on computed CSS properties to work with styles scoped to `ngx-extended-pdf-viewer` element